### PR TITLE
state was being built with filenames without the path

### DIFF
--- a/lib/ocflObject.js
+++ b/lib/ocflObject.js
@@ -236,7 +236,7 @@ class OcflObject {
       files.push(
         items.map((item) => {
           return {
-            name: item.split("/").pop(),
+            name: item.replace(/^v\d+\/content\//, ''),
             path: item,
             hash,
             version: parseInt(item.split("/").shift().replace("v", "")),


### PR DESCRIPTION
Our fix is evil. We should use a lookup in the object manifest?

This will break one of the test